### PR TITLE
Allow a logged in user to logout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,21 @@ class ApplicationController < ActionController::Base
   protect_from_forgery :with => :exception
   helper_method :current_user
 
+  private
+
   def current_user
     if session[:user_id].present?
       @current_user ||= User.find_by(:id => session[:user_id])
     end
 
     @current_user || GuestUser.new
+  end
+
+  def login(user)
+    session[:user_id] = user.id
+  end
+
+  def logout
+    session[:user_id] = nil
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,9 +3,14 @@ class SessionsController < ApplicationController
 
   def create
     run Authentication::LoginWithOmniAuth do |op|
-      session[:user_id] = op.user.id
+      login(op.user)
       return redirect_to root_path, :notice => "Successfully logged in!"
     end
+  end
+
+  def destroy
+    logout
+    redirect_to root_path, :notice => "Successfully logged out!"
   end
 
   private

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,6 +15,7 @@ html
         .col-md-12
           - if current_user.authenticated?
             p Logged in as #{current_user.nickname}
+            p= link_to "Logout", session_path, :method => :delete
           - else
             p= link_to "Login with GitHub", "/auth/github"
       .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root "home#show"
 
+  resource :session
+
   get "/auth/:provider/callback", :to => "sessions#create"
 end

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Authentication" do
-  describe "Logging in via GitHub" do
-    before { visit root_path }
+  before { visit root_path }
 
+  describe "Logging in via GitHub" do
     it "shows a success message" do
       click_on "Login with GitHub"
 
@@ -27,6 +27,19 @@ RSpec.describe "Authentication" do
           click_on "Login with GitHub"
         }.not_to change(User, :count)
       end
+    end
+  end
+
+  describe "Logging out" do
+    it "allows logged in users to logout" do
+      click_on "Login with GitHub"
+      click_on "Logout"
+
+      expect(page).to have_content(/successfully logged out/i)
+    end
+
+    it "doesn't show the logout link users not logged in" do
+      expect(page).not_to have_link("Logout")
     end
   end
 end


### PR DESCRIPTION
We have a logout link that is only visible if logged in. When clicked we
simply clear the user id from the session and redirect to the homepage.
I've added a `login` and `logout` method to the `ApplicationController`
to clean up the controller actions.

I'm thinking about moving the `current_user`, `login` and `logout`
methods to a separate class or operation that can manage them together
as they all need the session and are related. This will enable us to
move this logic out of the controllers. I'll come back to that later.
